### PR TITLE
Collect comments

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE osm_changeset (
   min_lat REAL,
   max_lon REAL,
   max_lat REAL,
+  msg VARCHAR(512),
   closed_at INTEGER,
   num_changes INTEGER
 );


### PR DESCRIPTION
I made some hacky edits to additionally collect `<tag k="comments" v="people's words and hashtags here"/>` from the expat stream into the sqlite database if anyone ever needs that.  The resulting sqlite database is easily queryable for hashtags using `select * from osm_changeset where msg LIKE "%#PeaceCorps%"` (a ~35s query on my 2011 MacBook)

and voila (centers of bounding boxes):
![peacecorps-osm](https://cloud.githubusercontent.com/assets/283343/13166459/2eee97f6-d696-11e5-8da1-5b1a7492d77f.gif)
